### PR TITLE
implementando arquivo com o PID do processo skink_console

### DIFF
--- a/skink_console.py
+++ b/skink_console.py
@@ -89,6 +89,9 @@ def run_skink_server():
     monitor = MonitorPlugin(cherrypy.engine, server)
     monitor.subscribe()
 
+    pid = cherrypy.process.plugins.PIDFile(cherrypy.engine, "/var/run/skink.pid")
+    pid.subscribe()
+
     try:
         server.start("config.ini", non_block=True)
         for plugin in SkinkPlugin.all():


### PR DESCRIPTION
com isso fica mais facil de descobrir o PID do skink para mandar sinais via bash.
